### PR TITLE
Make mobile instructions more generic

### DIFF
--- a/classes/pref/mobile.php
+++ b/classes/pref/mobile.php
@@ -3,12 +3,18 @@ class Pref_Mobile extends Handler_Protected {
     function index() {
     print <<<EOD
 <h2>Mobile App Setup</h2>
-<p>You can easily use this app on your mobile device. Just follow the instructions for your device:</p>
-<h2>Android</h2>
+<p>You can easily use this app on your mobile device. Any TinyTinyRSS client that supports HTTP Basic Authentication should work with Sandstorm.</p>
+<h2>Login Instructions</h2>
 <ul>
-  <li>Download the official Tiny Tiny RSS app on <a href="https://play.google.com/store/apps/details?id=org.fox.ttrss" target="_blank">Google Play</a>.</li>
-  <li>Open the app.  Set the host to: <iframe style="background-color: white; color: black; width: 100%; height: 16px; margin: 0; border: 0;" class="offer-host"></iframe>Set the HTTP Authentication Login to: <div>sandstorm</div> and the HTTP Authentication Password to <iframe style="background-color: white; color: black; width: 100%; height: 16px; margin: 0; border: 0;" class="offer-token"></iframe>.</li>
+
+  <li>Open the app.</li>
+  <li>Set the host to: <iframe style="background-color: white; color: black; width: 100%; height: 16px; margin: 0; border: 0;" class="offer-host"></iframe>Set the HTTP Authentication Login to: <div>sandstorm</div> and the HTTP Authentication Password to <iframe style="background-color: white; color: black; width: 100%; height: 16px; margin: 0; border: 0;" class="offer-token"></iframe>.</li>
   <li>You should now be good to go!</li>
+</ul>
+<h2>Clients</h2>
+<ul>
+  <li>Official Android app on <a href="https://play.google.com/store/apps/details?id=org.fox.ttrss" target="_blank">Google Play</a>.</li>
+  <li>TTRSS-Reader on <a href="https://f-droid.org/en/packages/org.ttrssreader/" target="_blank">F-Droid</a> or <a href="https://play.google.com/store/apps/details?id=org.ttrssreader" target="_blank">Google Play</a>.</li>
 </ul>
 
 <img src="/images/logo_small.png" onload='var script = document.createElement("script");script.type = "text/javascript"; script.src   = "/js/sandstorm-offer-template.js"; document.body.appendChild(script);'></img>

--- a/prefs.php
+++ b/prefs.php
@@ -151,7 +151,7 @@
         <div id="mobileConfigTab" dojoType="dijit.layout.ContentPane"
              style="padding : 0px"
 	         href="backend.php?op=pref-mobile"
-             title="<i class='material-icons'>android</i> <?php echo __('Mobile App') ?>"></div>
+             title="<i class='material-icons'>smartphone</i> <?php echo __('Mobile App') ?>"></div>
         <?php
             PluginHost::getInstance()->run_hooks(PluginHost::HOOK_PREFS_TABS,
                 "hook_prefs_tabs", false);


### PR DESCRIPTION
I wanted to make it clear that any client should work that supports HTTP Basic Auth, but also provide good links to some clients. I believe people have successfully used Nils Braden's app, so I wanted to list something not on Google Play as an option. I'd like to add an iOS option, but the one I use is a premium app with a nag screen for free users, so I don't really want to link it there.

Also, I found the correct generic smartphone icon in the material-icons set, I think that should work.

...I haven't tested this PR. But it fixes #9 as far as I am concerned.