### PR TITLE
Add Windows client

### DIFF
--- a/classes/pref/mobile.php
+++ b/classes/pref/mobile.php
@@ -15,10 +15,11 @@ class Pref_Mobile extends Handler_Protected {
   <li>Set the host to: <iframe style="background-color: white; color: black; width: 100%; height: 16px; margin: 0; border: 0;" class="offer-host"></iframe>Set the HTTP Authentication Login to: <div>sandstorm</div> and the HTTP Authentication Password to <iframe style="background-color: white; color: black; width: 100%; height: 16px; margin: 0; border: 0;" class="offer-token"></iframe>.</li>
   <li>You should now be good to go!</li>
 </ul>
-<h2>Clients</h2>
+<h2>Recommended Clients</h2>
 <ul>
   <li>Official Android app on <a href="https://play.google.com/store/apps/details?id=org.fox.ttrss" target="_blank">Google Play</a>.</li>
   <li>TTRSS-Reader on <a href="https://f-droid.org/en/packages/org.ttrssreader/" target="_blank">F-Droid</a> or <a href="https://play.google.com/store/apps/details?id=org.ttrssreader" target="_blank">Google Play</a>.</li>
+  <li>Tiny Tiny RSS Reader on the <a href="https://apps.microsoft.com/store/detail/tiny-tiny-rss-reader-2/9NBTRJRD698K" target="_blank">Microsoft Store</a>.</li>
 </ul>
 
 <img src="/images/logo_small.png" onload='var script = document.createElement("script");script.type = "text/javascript"; script.src   = "/js/sandstorm-offer-template.js"; document.body.appendChild(script);'></img>


### PR DESCRIPTION
So, little history here: I've used this app since my Windows Mobile days, and I still use it on desktop Windows today. It is well-tested with Sandstorm, the HTTP Basic Auth support was originally added by testing off of Oasis. The developer, Stefan Prasse, moved on to a PWA version, but posted up the source code. He gave me permission to re-publish it, and I've been working on patching up a couple fixes.

So I use this client every day, in this case, I now also publish it, and it definitely will work well with Sandstorm. I also added the word "Recommended", because we said any TTRSS client with HTTP Basic Auth is supported above, I don't want to give the impression you have to only use the ones listed in this section.