### PR TITLE
Rotate logs on startup.

### DIFF
--- a/.sandstorm/launcher.sh
+++ b/.sandstorm/launcher.sh
@@ -40,6 +40,14 @@ rm -rf /var/tmp
 mkdir -p /var/tmp
 mkdir -p /var/run/mysqld
 
+# Rotate log files larger than 512K
+log_files="$(find /var/log -type f -name '*.log')"
+for f in $log_files; do
+    if [ $(du -b "$f" | awk '{print $1}') -ge $((512 * 1024)) ] ; then
+        mv $f $f.1
+    fi
+done
+
 # Ensure mysql tables created
 HOME=/etc/mysql /usr/sbin/mysqld --initialize || true
 

--- a/.sandstorm/sandstorm-files.list
+++ b/.sandstorm/sandstorm-files.list
@@ -3,6 +3,7 @@
 # the app runs in dev mode. You may manually add or remove files, but don't
 # expect comments or ordering to be retained.
 bin
+etc/alternatives/awk
 etc/alternatives/php
 etc/bindresvport.blacklist
 etc/default/nss
@@ -423,11 +424,16 @@ proc/cpuinfo
 sandstorm-http-bridge
 sandstorm-http-bridge-config
 sandstorm-manifest
+usr/bin/awk
 usr/bin/bash
 usr/bin/cp
 usr/bin/dash
 usr/bin/diff
+usr/bin/du
+usr/bin/find
+usr/bin/mawk
 usr/bin/mkdir
+usr/bin/mv
 usr/bin/mysql
 usr/bin/php
 usr/bin/php7.3


### PR DESCRIPTION
Fixes #44, though note that this won't reduce the size of existing grains until the logs have been rotated twice, so error.log will have to grow to 512K again before the current log actually gets deleted.